### PR TITLE
Updating Readme and restoring Chromium support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Prerequisites:
 
 ```bash
 git clone https://github.com/benoitpetit/duckduckGO-chat-cli
-cd duckduckGO-chat-cli
+cd duckduckGO-chat-cli/cmd/duckchat
 go build -ldflags "-s -w" -o ddg-chat
 ```
 

--- a/cmd/duckchat/main.go
+++ b/cmd/duckchat/main.go
@@ -23,7 +23,7 @@ func main() {
 	color.Cyan("Welcome to DuckDuckGo AI Chat CLI!")
 
 	cfg := config.Initialize()
-	models.CheckChromeVersion()
+	//models.CheckChromeVersion()
 
 	if !config.AcceptTermsOfService(cfg) {
 		color.Yellow("You must accept the terms to use this app. Exiting.")


### PR DESCRIPTION
- updated instruction in readme, as main.go was moved in v1.1.2 resulting in build error
- restored Chromium support  by commenting out call for Chrome check function added in v1.1.2 [temporary fix]