### PR TITLE
Fix for the new vqd header in status api

### DIFF
--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -168,7 +168,7 @@ func GetVQD() string {
 		return ""
 	}
 	defer resp.Body.Close()
-	return resp.Header.Get("x-vqd-4")
+	return resp.Header.Get("x-vqd-hash-1")
 }
 
 func (c *Chat) Clear(cfg *config.Config) {


### PR DESCRIPTION
Fixes #10 

where in new response headers, `x-vqd-4` is changed to `x-vqd-hash-1`