### PR TITLE
Added support for building for Intel Mac (AMD64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,22 +144,29 @@ jobs:
         echo "📦 Building Darwin ARM64..."
         GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=v$VERSION" -o $BUILD_DIR/duckduckgo-chat-cli_v${VERSION}_darwin_arm64 ./cmd/duckchat/main.go
         
+        # Build for Intel Mac
+        echo "📦 Building Darwin AMD64..."
+        GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=v$VERSION" -o $BUILD_DIR/duckduckgo-chat-cli_v${VERSION}_darwin_amd64 ./cmd/duckchat/main.go
+        
         # Generate SHA256 hashes
         echo "🔐 Generating SHA256 hashes..."
         cd $BUILD_DIR
         sha256sum duckduckgo-chat-cli_v${VERSION}_windows_amd64.exe > duckduckgo-chat-cli_v${VERSION}_windows_amd64.exe.sha256
         sha256sum duckduckgo-chat-cli_v${VERSION}_linux_amd64 > duckduckgo-chat-cli_v${VERSION}_linux_amd64.sha256
         sha256sum duckduckgo-chat-cli_v${VERSION}_darwin_arm64 > duckduckgo-chat-cli_v${VERSION}_darwin_arm64.sha256
+        sha256sum duckduckgo-chat-cli_v${VERSION}_darwin_amd64 > duckduckgo-chat-cli_v${VERSION}_darwin_amd64.sha256
         
         # Create release archive
         echo "📚 Creating release archive..."
         zip duckduckgo-chat-cli_v${VERSION}_release.zip \
             duckduckgo-chat-cli_v${VERSION}_linux_amd64 \
             duckduckgo-chat-cli_v${VERSION}_darwin_arm64 \
+            duckduckgo-chat-cli_v${VERSION}_darwin_amd64 \
             duckduckgo-chat-cli_v${VERSION}_windows_amd64.exe \
             duckduckgo-chat-cli_v${VERSION}_windows_amd64.exe.sha256 \
             duckduckgo-chat-cli_v${VERSION}_linux_amd64.sha256 \
-            duckduckgo-chat-cli_v${VERSION}_darwin_arm64.sha256
+            duckduckgo-chat-cli_v${VERSION}_darwin_arm64.sha256 \
+            duckduckgo-chat-cli_v${VERSION}_darwin_amd64.sha256
         
         echo "✅ Build v$VERSION complete!"
         ls -lah

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,12 +152,23 @@ jobs:
         fi
         
         # Test macOS build
+        # Test macOS ARM build
         GOOS=darwin GOARCH=arm64 go build -o test_darwin ./cmd/duckchat/main.go
         if [ -f "test_darwin" ]; then
           echo "✅ Darwin ARM64 build successful"
           rm test_darwin
         else
           echo "❌ Darwin ARM64 build failed"
+          exit 1
+        fi
+        
+        # Test macOS Intel build
+        GOOS=darwin GOARCH=amd64 go build -o test_darwin_amd64 ./cmd/duckchat/main.go
+        if [ -f "test_darwin_amd64" ]; then
+          echo "✅ Darwin AMD64 build successful"
+          rm test_darwin_amd64
+        else
+          echo "❌ Darwin AMD64 build failed"
           exit 1
         fi
         

--- a/README.md
+++ b/README.md
@@ -167,8 +167,17 @@ curl -LO $(curl -s https://api.github.com/repos/benoitpetit/duckduckGO-chat-cli/
 <details>
 <summary><strong>🍎 MacOS (curl)</strong></summary>
 
+<br/>
+<strong>Apple Silicon (ARM64):</strong>
+
 ```bash
 curl -LO $(curl -s https://api.github.com/repos/benoitpetit/duckduckGO-chat-cli/releases/latest | grep -oP 'https.*darwin_arm64' | grep -oP 'https.*v[0-9]+\.[0-9]+\.[0-9]+_darwin_arm64' | head -1) && chmod +x duckduckgo-chat-cli_v*_darwin_arm64 && ./duckduckgo-chat-cli_v*_darwin_arm64
+```
+
+<strong>Intel (AMD64):</strong>
+
+```bash
+curl -LO $(curl -s https://api.github.com/repos/benoitpetit/duckduckGO-chat-cli/releases/latest | grep -oP 'https.*darwin_amd64' | grep -oP 'https.*v[0-9]+\.[0-9]+\.[0-9]+_darwin_amd64' | head -1) && chmod +x duckduckgo-chat-cli_v*_darwin_amd64 && ./duckduckgo-chat-cli_v*_darwin_amd64
 ```
 
 </details>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,12 +49,17 @@ cd ..
 echo "📦 Building Darwin ARM64..."
 GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=v$VERSION" -o $BUILD_DIR/duckduckgo-chat-cli_v${VERSION}_darwin_arm64 ./cmd/duckchat/main.go
 
+# Build pour Intel Mac
+echo "📦 Building Darwin AMD64..."
+GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=v$VERSION" -o $BUILD_DIR/duckduckgo-chat-cli_v${VERSION}_darwin_amd64 ./cmd/duckchat/main.go
+
 # Création du zip de release
 echo "📚 Creating release archive..."
 cd $BUILD_DIR
 zip duckduckgo-chat-cli_v${VERSION}_release.zip \
     duckduckgo-chat-cli_v${VERSION}_linux_amd64 \
     duckduckgo-chat-cli_v${VERSION}_darwin_arm64 \
+    duckduckgo-chat-cli_v${VERSION}_darwin_amd64 \
     duckduckgo-chat-cli_v${VERSION}_windows_amd64.exe \
     duckduckgo-chat-cli_v${VERSION}_windows_amd64.exe.sha256
 cd ..

--- a/scripts/pre-release-check.sh
+++ b/scripts/pre-release-check.sh
@@ -65,6 +65,7 @@ log_info "Checking cross-platform builds..."
 check "GOOS=linux GOARCH=amd64 go build -o /tmp/test_linux ./cmd/duckchat/main.go && rm -f /tmp/test_linux" "Linux AMD64 build"
 check "GOOS=windows GOARCH=amd64 go build -o /tmp/test_windows.exe ./cmd/duckchat/main.go && rm -f /tmp/test_windows.exe" "Windows AMD64 build"
 check "GOOS=darwin GOARCH=arm64 go build -o /tmp/test_darwin ./cmd/duckchat/main.go && rm -f /tmp/test_darwin" "Darwin ARM64 build"
+check "GOOS=darwin GOARCH=amd64 go build -o /tmp/test_darwin_amd64 ./cmd/duckchat/main.go && rm -f /tmp/test_darwin_amd64" "Darwin AMD64 build"
 
 # Git verification
 log_info "Checking Git..."


### PR DESCRIPTION
---
Name: 🚀 Pull Request to Production
Assignees: 'benoitpetit'
---

## 📋 Description
- Makes it so it also builds the Intel Mac variant. Very small updates to the scripts folder. 
- I found out it wasn't in there (I'm still running a Intel Mac). The build was for wrong CPU architecture (ARM64). Changes to the build file make it so it makes the executable and puts it in the distribution zip. 
- Also I've added the build to the check in the GitHub workflows.
- Finally, I've added a part for installing on Intel Mac to the MacOS section in the README. 

## 🆕 New Features
- [x] Added AMD64 to the build script for darwin (building for Intel Mac), also updated the README accordingly.

## ⚠️ Breaking Changes
- [x] No breaking changes.

## 🧪 Testing
- [x] Test (building) passes locally.
- [x] Manual testing performed.
