### PR TITLE
Add GPT-5-mini (beta) to Supported Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ Never lose important conversations:
 
 ## 🤖 Available Models
 
-| Model Name            | Integration ID                               | Alias              | Strength                 | Best For                             | Characteristics                                                                           |
-| :-----------------    | :----------------------------------------    | :-------------     | :-------------------     | :-----------------------             | :----------------------------------                                                       |
-| **GPT-5-Mini**        | gpt-5-mini                                   | gpt-5-mini         | Adaptive problem-solving | Multimodal reasoning                 | • Context-aware<br>• Efficient with nuance<br>• Handles mixed data (text, images, tables) |
-| **GPT-4o mini**       | gpt-4o-mini                                  | gpt-4o-mini        | General purpose          | Everyday questions                   | • Fast<br>• Well-balanced                                                                 |
-| **Claude 3 Haiku**    | claude-3-haiku-20240307                      | claude-3-haiku     | Creative writing         | Explanations & summaries             | • Clear responses<br>• Concise                                                            |
-| **Llama 3.3 70B**     | meta-llama/Llama-3.3-70B-Instruct-Turbo      | llama              | Programming              | Code-related tasks                   | • Technical precision<br>• Detailed                                                       |
-| **Mistral Small**     | mistralai/Mistral-Small-24B-Instruct-2501    | mixtral            | Knowledge & analysis     | Complex topics                       | • Reasoning<br>• Logic-focused                                                            |
-| **o4-mini**           | o4-mini                                      | o4mini             | Speed                    | Quick answers                        | • Very fast<br>• Compact responses                                                        |
+| Model Name         | Integration ID                            | Alias          | Strength                 | Best For                 | Characteristics                            |
+| :----------------- | :---------------------------------------- | :------------- | :----------------------- | :----------------------- | :----------------------------------------- |
+| **GPT-5-Mini**     | gpt-5-mini                                | gpt-5-mini     | Adaptive problem-solving | Multimodal reasoning     | • Context-aware<br>• Efficient with nuance |
+| **GPT-4o mini**    | gpt-4o-mini                               | gpt-4o-mini    | General purpose          | Everyday questions       | • Fast<br>• Well-balanced                  |
+| **Claude 3 Haiku** | claude-3-haiku-20240307                   | claude-3-haiku | Creative writing         | Explanations & summaries | • Clear responses<br>• Concise             |
+| **Llama 3.3 70B**  | meta-llama/Llama-3.3-70B-Instruct-Turbo   | llama          | Programming              | Code-related tasks       | • Technical precision<br>• Detailed        |
+| **Mistral Small**  | mistralai/Mistral-Small-24B-Instruct-2501 | mixtral        | Knowledge & analysis     | Complex topics           | • Reasoning<br>• Logic-focused             |
+| **o4-mini**        | o4-mini                                   | o4mini         | Speed                    | Quick answers            | • Very fast<br>• Compact responses         |
 
 ## 📦 Installation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ### 💬 Chat Experience
 - **🔄 Real-time streaming** - Live response display with smooth markdown formatting
-- **🤖 Multiple AI models** - GPT-4o mini, Claude 3 Haiku, Llama 3.3, Mistral Small, o4-mini & more
+- **🤖 Multiple AI models** - GPT-4o mini, GPT-5 mini, Claude 3 Haiku, Llama 3.3, Mistral Small, o4-mini & more
 - **💻 Terminal-native** - Optimized for command-line workflows with interactive menus
 - **⌨️ Smart autocompletion** - Interactive command menus and context-aware suggestions
 - **🔑 Auto-authentication** - Seamless session management with dynamic header refresh
@@ -132,13 +132,14 @@ Never lose important conversations:
 
 ## 🤖 Available Models
 
-| Model Name         | Integration ID                            | Alias          | Strength         | Best For             | Characteristics              |
-| :----------------- | :---------------------------------------- | :------------- | :------------------- | :----------------------- | :---------------------------------- |
-| **GPT-4o mini**    | gpt-4o-mini                               | gpt-4o-mini    | General purpose      | Everyday questions       | • Fast<br>• Well-balanced           |
-| **Claude 3 Haiku** | claude-3-haiku-20240307                   | claude-3-haiku | Creative writing     | Explanations & summaries | • Clear responses<br>• Concise      |
-| **Llama 3.3 70B**  | meta-llama/Llama-3.3-70B-Instruct-Turbo   | llama          | Programming          | Code-related tasks       | • Technical precision<br>• Detailed |
-| **Mistral Small**  | mistralai/Mistral-Small-24B-Instruct-2501 | mixtral        | Knowledge & analysis | Complex topics           | • Reasoning<br>• Logic-focused      |
-| **o4-mini**        | o4-mini                                   | o4mini         | Speed                | Quick answers            | • Very fast<br>• Compact responses  |
+| Model Name            | Integration ID                               | Alias              | Strength                 | Best For                             | Characteristics                                                                           |
+| :-----------------    | :----------------------------------------    | :-------------     | :-------------------     | :-----------------------             | :----------------------------------                                                       |
+| **GPT-5-Mini**        | gpt-5-mini                                   | gpt-5-mini         | Adaptive problem-solving | Multimodal reasoning                 | • Context-aware<br>• Efficient with nuance<br>• Handles mixed data (text, images, tables) |
+| **GPT-4o mini**       | gpt-4o-mini                                  | gpt-4o-mini        | General purpose          | Everyday questions                   | • Fast<br>• Well-balanced                                                                 |
+| **Claude 3 Haiku**    | claude-3-haiku-20240307                      | claude-3-haiku     | Creative writing         | Explanations & summaries             | • Clear responses<br>• Concise                                                            |
+| **Llama 3.3 70B**     | meta-llama/Llama-3.3-70B-Instruct-Turbo      | llama              | Programming              | Code-related tasks                   | • Technical precision<br>• Detailed                                                       |
+| **Mistral Small**     | mistralai/Mistral-Small-24B-Instruct-2501    | mixtral            | Knowledge & analysis     | Complex topics                       | • Reasoning<br>• Logic-focused                                                            |
+| **o4-mini**           | o4-mini                                      | o4mini             | Speed                    | Quick answers                        | • Very fast<br>• Compact responses                                                        |
 
 ## 📦 Installation
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -176,7 +176,7 @@ func GetAvailableModels() []ModelInfo {
 			IsDefault:   true,
 		},
 		{
-			ID:          "gpt-5-mini",
+			ID:          "gpt-5-mini", 
 			Name:        "GPT-5-mini",
 			Description: "Fast, high-quality model for advanced reasoning and concise responses",
 			IsDefault:   false,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -176,6 +176,12 @@ func GetAvailableModels() []ModelInfo {
 			IsDefault:   true,
 		},
 		{
+			ID:          "gpt-5-mini",
+			Name:        "GPT-5-mini",
+			Description: "Fast, high-quality model for advanced reasoning and concise responses",
+			IsDefault:   false,
+		},
+		{
 			ID:          "claude-3-haiku",
 			Name:        "Claude-3-haiku",
 			Description: "Anthropic's Claude 3 Haiku model for thoughtful responses",

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -382,6 +382,7 @@ func ProcessInputAndReturn(c *Chat, input string, cfg *config.Config) (string, e
 func shortenModelName(model string) string {
 	displayNames := map[string]models.ModelAlias{
 		"gpt-4o-mini":                               "gpt-4o-mini",
+		"gpt-5-mini":                                "gpt-5-mini",
 		"claude-3-haiku-20240307":                   "claude-3-haiku",
 		"meta-llama/Llama-3.3-70B-Instruct-Turbo":   "llama",
 		"mistralai/Mistral-Small-24B-Instruct-2501": "mixtral",

--- a/internal/chat/export.go
+++ b/internal/chat/export.go
@@ -186,6 +186,7 @@ func sanitizeFilename(name string) string {
 func formatModelName(modelName string) string {
 	displayNames := map[string]string{
 		"gpt-4o-mini":                             "GPT-4o mini",
+		"gpt-5-mini":                              "GPT-5 mini",
 		"claude-3-haiku-20240307":                 "Claude 3 Haiku",
 		"meta-llama/Llama-3.3-70B-Instruct-Turbo": "Llama 3.3 70B",
 		"mistralai/Mixtral-8x7B-Instruct-v0.1":    "Mistral 8x7B",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,6 +248,7 @@ func handleModelChange(cfg *Config, chatSession interfaces.ChatSession) {
 	prompt := &survey.Select{
 		Message: "Choose Default Model:",
 		Options: []string{
+			"gpt-5-mini",
 			"gpt-4o-mini",
 			"claude-3-haiku",
 			"llama",

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -27,12 +27,14 @@ type ModelAlias string
 
 const (
 	GPT4Mini Model = "gpt-4o-mini"
+	GPT5Mini Model = "gpt-5-mini"
 	Claude3  Model = "claude-3-haiku-20240307"
 	Llama    Model = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
 	Mixtral  Model = "mistralai/Mistral-Small-24B-Instruct-2501"
 	o4mini   Model = "o4-mini"
 
 	GPT4MiniAlias ModelAlias = "gpt-4o-mini"
+	GPT5MiniAlias ModelAlias = "gpt-5-mini"
 	Claude3Alias  ModelAlias = "claude-3-haiku"
 	LlamaAlias    ModelAlias = "llama"
 	MixtralAlias  ModelAlias = "mixtral"
@@ -41,6 +43,7 @@ const (
 
 var modelMap = map[ModelAlias]Model{
 	GPT4MiniAlias: GPT4Mini,
+	GPT5MiniAlias: GPT5Mini,
 	Claude3Alias:  Claude3,
 	LlamaAlias:    Llama,
 	MixtralAlias:  Mixtral,
@@ -49,6 +52,7 @@ var modelMap = map[ModelAlias]Model{
 
 var modelDisplayMap = map[Model]string{
 	GPT4Mini: "GPT-4o-mini",
+	GPT5Mini: "GPT-5-mini",
 	Claude3:  "Claude-3-haiku",
 	Llama:    "Llama 3.3",
 	Mixtral:  "Mistral Small 3",
@@ -213,6 +217,7 @@ func HandleModelChange(chat interface{}, modelArg string) ModelAlias {
 	// Show an interactive menu if no argument is provided
 	modelOptions := []string{
 		"GPT-4o-mini",
+		"GPT-5-mini",
 		"Claude-3-haiku",
 		"Llama 3.3",
 		"Mistral Small 3",
@@ -241,6 +246,8 @@ func HandleModelChange(chat interface{}, modelArg string) ModelAlias {
 	switch strings.ToLower(choice) {
 	case "gpt-4o-mini":
 		return GPT4MiniAlias
+	case "gpt-5-mini":
+		return GPT5MiniAlias
 	case "claude-3-haiku":
 		return Claude3Alias
 	case "llama 3.3":


### PR DESCRIPTION
---

## 📋 Description
- DuckDuckGo now supports **GPT-5-mini (beta)**.  
- This PR extends the current models list to reflect the updated availability.

## 🆕 New Features
- [x] Added support for **GPT-5 mini (beta)**

## ⚠️ Breaking Changes
- [x] No breaking changes

## 🧪 Testing
- [x] Tests pass locally
- [x] Cross-platform builds work
- [x] Manual testing performed